### PR TITLE
LED Breathe Project and Project Runner Improvements

### DIFF
--- a/Config/NLog.config
+++ b/Config/NLog.config
@@ -9,24 +9,29 @@
   <!-- the targets to write to -->
   <targets>
     <!-- write logs to file -->
-    <target xsi:type="File" name="Error" fileName="../logs/Error.log"
+    <target xsi:type="File" name="Error" fileName="../logs/error.log"
             layout="${longdate} | ${level:uppercase=true} | ${message} ${when:when=length('${exception}')>0:Inner=${newline}}${exception:format=tostring}" />
 
-    <target xsi:type="File" name="General" fileName="../logs/General.log"
+    <target xsi:type="File" name="General" fileName="../logs/general.log"
             layout="${longdate} | ${level:uppercase=true} | ${message} ${when:when=length('${exception}')>0:Inner=${newline}}${exception:format=tostring}" />
 
     <!-- project logs -->
     <target xsi:type="File" name="LEDBlink" fileName="../logs/LEDBlink.log"
             layout="${longdate} | ${level:uppercase=true} | ${message} ${when:when=length('${exception}')>0:Inner=${newline}}${exception:format=tostring}" />
 
+    <target xsi:type="File" name="LEDBreathe" fileName="../logs/LEDBreathe.log"
+            layout="${longdate} | ${level:uppercase=true} | ${message} ${when:when=length('${exception}')>0:Inner=${newline}}${exception:format=tostring}" />
+
     <target xsi:type="File" name="LEDSwitch" fileName="../logs/LEDSwitch.log"
             layout="${longdate} | ${level:uppercase=true} | ${message} ${when:when=length('${exception}')>0:Inner=${newline}}${exception:format=tostring}" />
+
   </targets>
 
   <!-- rules to map from logger name to target -->
   <rules>  
     <!-- project targets -->
     <logger name="*.LEDBlink" minlevel="Trace" maxLevel="Warn" final="true" writeTo="LEDBlink" />
+    <logger name="*.LEDBreathe" minlevel="Trace" maxLevel="Warn" final="true" writeTo="LEDBreathe" />
     <logger name="*.LEDSwitch" minlevel="Trace" maxLevel="Warn" final="true" writeTo="LEDSwitch" />
     
     <!-- general targets -->

--- a/Config/appsettings.json
+++ b/Config/appsettings.json
@@ -6,13 +6,18 @@
       "RunOnStart": true
     },
     {
+      "Name": "LEDBreathe",
+      "Runnable": true,
+      "RunOnStart":  true
+    },
+    {
       "Name": "LEDSwitch",
       "Runnable": true
     }
   ],
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
+      "Default": "Trace"
     }
   }
 }

--- a/GPIOInterfaces/IProject.cs
+++ b/GPIOInterfaces/IProject.cs
@@ -1,7 +1,11 @@
-﻿namespace GPIOInterfaces
+﻿using System.Collections.Generic;
+
+namespace GPIOInterfaces
 {
     public interface IProject
     {
+        public List<int> Pins { get; }
+
         public void RunProject();
     }
 }

--- a/GPIOProjects/Base/BaseProject.cs
+++ b/GPIOProjects/Base/BaseProject.cs
@@ -1,5 +1,7 @@
 ﻿using GPIOInterfaces;
 using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
 using System.Device.Gpio;
 
 namespace GPIOProjects.Base
@@ -7,8 +9,9 @@ namespace GPIOProjects.Base
     public abstract class BaseProject : IProject
     {
         protected readonly GpioController _controller;
-
         protected readonly ILogger<IProject> _logger;
+
+        public abstract List<int> Pins { get; }
 
         protected BaseProject(GpioController controller, ILogger<IProject> logger)
         {
@@ -20,9 +23,16 @@ namespace GPIOProjects.Base
         {
             _logger.LogTrace("------------------------------------------");
 
-            Startup();
+            try
+            {
+                Startup();
 
-            Run();
+                Run();
+            }
+            catch (Exception ex) 
+            {
+                _logger.LogError(ex, "Error running project.");
+            }
         }
 
         protected abstract void Startup();

--- a/GPIOProjects/LED/LEDBlink.cs
+++ b/GPIOProjects/LED/LEDBlink.cs
@@ -1,17 +1,25 @@
 ﻿using GPIOProjects.Base;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Device.Gpio;
 using System.Threading;
 
-namespace GPIOProjects
+namespace GPIOProjects.LED
 {
     public class LEDBlink : BaseProject
     {
-        private const int _pin = 18;
-        private const int _sleepTime = 500;
+        private readonly int _pin;
+        private readonly List<int> _pins;
+        private const int _sleepTime = 200;
 
-        public LEDBlink(GpioController controller, ILogger<LEDBlink> logger) : base(controller, logger) { }
+        public override List<int> Pins => _pins;
+
+        public LEDBlink(GpioController controller, ILogger<LEDBlink> logger) : base(controller, logger) 
+        {
+            _pin = 18;
+            _pins = new List<int> { _pin };
+        }
 
         protected override void Run()
         {

--- a/GPIOProjects/LED/LEDBreathe.cs
+++ b/GPIOProjects/LED/LEDBreathe.cs
@@ -1,0 +1,67 @@
+﻿using GPIOProjects.Base;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Device.Gpio;
+using System.Device.Pwm;
+using System.Threading;
+
+namespace GPIOProjects.LED
+{
+    public class LEDBreathe : BaseProject
+    {
+        // ---------------------------------------------------- DEFAULT PIN ----------------------------------------------------
+        // I have setup my RPi's boot configuration to enable a hardware PWM channel on pin 12 at start up.
+        // If PWM pin's mode is overwritten by a project, hardware PWM will no longer work and the RPi will need to be rebooted.
+        // See: https://github.com/dotnet/iot/blob/master/Documentation/raspi-pwm.md
+        // ---------------------------------------------------------------------------------------------------------------------
+
+        private const int _frequency = 1024;
+        private readonly List<int> _pins;
+        private PwmChannel _pwmChannel;
+
+        public override List<int> Pins => _pins;
+
+        public LEDBreathe(GpioController controller, ILogger<LEDBreathe> logger) : base(controller, logger) 
+        {
+            _pins = new List<int> { 12 };
+        }
+
+        protected override void Run()
+        {
+            _logger.LogTrace("Running LEDBreathe.cs");
+
+            using (_pwmChannel)
+            {
+                _pwmChannel.Start();
+
+                var cancellationTokenSource = new CancellationTokenSource(new TimeSpan(hours: 0, minutes: 0, seconds: 10));
+                do
+                {
+                    _logger.LogTrace("Increasing brightness...");
+                    for (int i = 0; i <= _frequency; i++)
+                    {
+                        _pwmChannel.DutyCycle = (double)i / _frequency;
+                        Thread.Sleep(2);
+                    }
+
+                    _logger.LogTrace("Decreasing brightness...");
+                    for (int i = _frequency; i >= 0; i--)
+                    {
+                        _pwmChannel.DutyCycle = (double)i / _frequency;
+                        Thread.Sleep(2);
+                    }
+
+                } while (!cancellationTokenSource.Token.IsCancellationRequested);
+
+                _pwmChannel.Stop();
+            }
+        }
+
+        protected override void Startup()
+        {
+            _logger.LogTrace("Setting up default PWM channel.");
+            _pwmChannel = PwmChannel.Create(chip: 0, channel: 0, _frequency, dutyCyclePercentage: 0.0);
+        }
+    }
+}

--- a/GPIOProjects/LED/LEDSwitch.cs
+++ b/GPIOProjects/LED/LEDSwitch.cs
@@ -1,15 +1,22 @@
 ﻿using GPIOProjects.Base;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Device.Gpio;
 
-namespace GPIOProjects
+namespace GPIOProjects.LED
 {
     public class LEDSwitch : BaseProject
     {
-        private const int _pin = 18;
+        private readonly int _pin;
+        private readonly List<int> _pins;
+        public override List<int> Pins => _pins;
 
-        public LEDSwitch(GpioController controller, ILogger<LEDSwitch> logger) : base(controller, logger) { }
+        public LEDSwitch(GpioController controller, ILogger<LEDSwitch> logger) : base(controller, logger) 
+        {
+            _pin = 18;
+            _pins = new List<int> { _pin };
+        }
 
         protected override void Run()
         {
@@ -25,8 +32,6 @@ namespace GPIOProjects
                 _logger.LogTrace("Switching on LED...");
                 _controller.Write(_pin, PinValue.High);
             }
-            else
-                throw new ApplicationException("Unknown Pin Value.");
         }
 
         protected override void Startup()

--- a/GPIORunner/Program.cs
+++ b/GPIORunner/Program.cs
@@ -1,5 +1,4 @@
 ﻿using GPIOInterfaces;
-using GPIOProjects;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -13,6 +12,7 @@ using GPIOProjects.Runner;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using NLog.Extensions.Logging;
+using GPIOProjects.LED;
 #if DEBUG
 using System.Diagnostics;
 using System.Threading;
@@ -110,8 +110,10 @@ namespace GPIORunner
             services.AddSingleton<GpioController>();
             services.AddSingleton<IProjectRunner, ProjectRunner>();
 
+            // LED Projects
             services.AddTransient<LEDBlink>();
             services.AddTransient<LEDSwitch>();
+            services.AddTransient<LEDBreathe>();
 
             return services;
         }


### PR DESCRIPTION
Added new LEDBreathe project. Added error logging for exceptions thrown in projects. Implemented changes to ProjectRunner service to work on active pins, essentially allowing multiple projects to run simultaneously, as long as their pins aren't shared. Added Pins property to IProject interface to facilitate this. Added object locking in ProjectRunner to avoid race conditions. Moved all LED related projects into their own folder.